### PR TITLE
refactor: update plugin name and API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# openboard
-Figma Plugin | add missing artboard feature to Figma
+# openplugin-figma
+
+Adding missing artboard feature to Figma

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
-  "name": "openboard",
+  "name": "openplugin",
   "id": "artboard-selector",
-  "api": "1.1.0",
+  "api": "1.0.0",
   "main": "code.js",
   "ui": "ui.html",
   "capabilities": [],

--- a/package.json
+++ b/package.json
@@ -1,0 +1,4 @@
+{
+    "name": "openplugin-figma",
+    "version": "0.1.0"
+}


### PR DESCRIPTION
Changes:
- Renamed plugin from "openboard" to "openplugin" for better clarity.
- Updated API version from "1.1.0" to "1.0.0" to align with current functionality.
- Updated README to reflect the new plugin name and provide a clearer description of its purpose.